### PR TITLE
Support triu function for `tvm.relay.expr.Call` Inputs

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -5057,11 +5057,6 @@ class PyTorchOpConverter:
         # use a cunter to prevent from messing up its scope in span
         empty_counter = 0
 
-        # TODO REMOVE BEFORE PR???
-        # * This is for debug purposes
-        converted_operators = 0
-        max_operators = 0
-
         self.input_remap = input_remap
         for node_name, op_node in operators:
 
@@ -5144,15 +5139,6 @@ class PyTorchOpConverter:
                 else:
                     relay_op = self.convert_map[operator]
 
-                # TODO REMOVE BEFORE PR
-                # * It is normal for max_operators to increase for a while. It will eventually stop.
-                converted_operators+=1
-                max_operators = len(outputs)
-                #print("relay_op: ", relay_op)
-                #print("OP_Node: ", op_node)
-                #print("OP inputs: ", _get_op_inputs(op_node, outputs, self.input_remap))
-                print(f"Converted {converted_operators}/{max_operators}")
-
                 self._set_parameter_source_name(op_node, outputs, self.input_remap)
                 relay_out = relay_op(
                     # since the elements in "outputs" may change due to span-filling process
@@ -5175,9 +5161,6 @@ class PyTorchOpConverter:
                     outputs[node_name] = relay_out
 
             self.current_op.pop()
-
-        # TODO REMOVE BEFORE PR
-        print("Finished converting. Some background operations will now continue but trust me it is not hanging. This will take a while...")
 
         # TODO(@haoyang9804): outputs[ret_name] could be None and cause some issue
         # revealed by https://github.com/apache/tvm/issues/15004


### PR DESCRIPTION
This PR is to address https://github.com/tenstorrent/tt-tvm/issues/3

Having a proper support for triangular upper when the inputs are a list of `CallNode`s will allow us to be a step closer to successfully implementing Qwen 1.5 (0.5B)  (See https://github.com/tenstorrent/tt-buda-demos/issues/20).

# Explanation
```diff
def triu(self, inputs, input_types):
    x = inputs[0]
    x_shape = _infer_shape(x)

+    if isinstance(inputs[0], tvm.relay.expr.Call):
+        return self.trilu(inputs, input_types, mode="triu")
        
    mask = np.triu(np.ones(x_shape), inputs[1]).astype(np.bool)
    mask = tvm.nd.array(mask)
    mask = tvm.relay.Constant(mask)

    zeros = np.zeros(x_shape).astype(_convert_tvm_to_np_dtype(input_types[0]))
    zeros = tvm.nd.array(zeros)
    zeros = tvm.relay.Constant(zeros)
        
    return _op.where(mask, x, zeros)
```

When compiling Qwen 1.5 (0.5B)  (https://github.com/tenstorrent/tt-buda-demos/pull/37), one of its OP codes is `aten::triu` with its inputs containing nested functions of OP calls.

```python
>> inputs[0]
CallNode(Op(add), [CallNode(Op(subtract), [CallNode(Op(subtract), [CallNode(Op(add), [Constant(256), Constant(0)], (nullptr), []), CallNode(Op(multiply), [Constant(1), Constant(256)], (nullptr), [])], (nullptr), []), CallNode(Op(multiply), [Constant(1), Constant(32768)], (nullptr), [])], (nullptr), []), Constant(1)], (nullptr), [])

>> type(inputs[0])
<tvm.relay.expr.Call>
```

`self.trilu` seems to be able to successfully handle these inputs when `mode="upper"` to do triangular upper operation.

# Issues
## 1 `Op(trilu)` instead of `Op(triu)`
After doing `self.trilu(inputs, input_types, mode="triu")`, the resulting output would be:
```python
CallNode(Op(trilu), [CallNode(Op(cast), [CallNode(Op(ones_like), [CallNode(Op(add),...
```
Is this a genuine issue??? Or can it be ignored for now?

## 2. NaN tensor values for Grayskull e75
When tested on @marty1885's e75, he ran into an error where his tensor values were NaN.
But weirdly @JonathanALevine's e150 was able to successfully compile and run it until running into some errors later.

*This is a draft for now since this is just a workaround and not a proper fix yet.




