### PR TITLE
Register strategy for pixel shuffle

### DIFF
--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -222,6 +222,15 @@ def compute_scatter_nd(attrs, inputs, output_type):
 
 _reg.register_strategy("scatter_nd", strategy.scatter_nd_strategy)
 
+# pixel_shuffle
+@_reg.register_compute("pixel_shuffle")
+def compute_pixel_shuffle(attrs, inputs, output_type):
+    """Compute definition of pixel_shuffle"""
+    return [topi.pixel_shuffle(inputs[0], attrs.upscale_factor)]
+
+
+_reg.register_strategy("pixel_shuffle", strategy.pixel_shuffle_strategy)
+
 # cumsum
 @_reg.register_compute("cumsum")
 def compute_cumsum(attrs, inputs, output_type):

--- a/python/tvm/topi/testing/__init__.py
+++ b/python/tvm/topi/testing/__init__.py
@@ -63,6 +63,7 @@ from .poolnd_python import poolnd_python
 from .pool_grad_python import pool_grad_nchw
 from .one_hot import one_hot
 from .depth_to_space import depth_to_space_python
+from .pixel_shuffle_python import pixel_shuffle_python
 from .space_to_depth import space_to_depth_python
 from .crop_and_resize_python import crop_and_resize_python
 from .common import (

--- a/python/tvm/topi/testing/pixel_shuffle_python.py
+++ b/python/tvm/topi/testing/pixel_shuffle_python.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2019-2023 The Apache Software Foundation
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, line-too-long, unused-variable, too-many-locals
+"""Pixel shuffle in python"""
+import numpy as np
+
+def pixel_shuffle_python(data, upscale_factor):
+    """Pixel Shuffle operator in Python.
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        N-D with shape (d_0, d_1, ..., d_{N-1})
+
+    upscale_factor : int or tuple of ints
+        Integer value to be upscaled with
+
+    Returns
+    -------
+    ret : numpy.ndarray
+        The computed result.
+    """
+    b, c, h, w = data.shape
+    upscale_squared = upscale_factor * upscale_factor
+    assert c % upscale_squared == 0, f"The number of channels ({c}) is not divisible by upscale_factor squared ({upscale_squared})."
+    oc = c // upscale_squared
+    oh = h * upscale_factor
+    ow = w * upscale_factor
+    new_shape = (b, oc, upscale_factor, upscale_factor, h, w)
+    out_shape = (b, oc, oh, ow)
+    data = np.reshape(data, new_shape)
+    data = np.transpose(data, (0, 1, 4, 2, 5, 3))
+    out_np = np.reshape(data, out_shape)
+    return out_np

--- a/tests/python/topi/python/test_topi_transform.py
+++ b/tests/python/topi/python/test_topi_transform.py
@@ -29,7 +29,25 @@ from tvm.contrib.nvcc import have_fp16
 
 import tvm.testing
 
+def verify_pixel_shuffle(in_shape, upscale_factor):
+    A = te.placeholder(shape=in_shape, name="A")
+    B = topi.pixel_shuffle(A, upscale_factor)
+    
+    def check_device(target, dev):
+        print("Running on target: %s" % target)
+        with tvm.target.Target(target):
+            s = tvm.topi.testing.get_injective_schedule(target)(B)
+        foo = tvm.build(s, [A, B], target, name="pixel_shuffle")
+        data_npy = np.random.normal(size=in_shape).astype(A.dtype)
+        out_npy = tvm.topi.testing.pixel_shuffle_python(data_npy, upscale_factor)
+        data_nd = tvm.nd.array(data_npy, dev)
+        out_nd = tvm.nd.empty(out_npy.shape, device=dev, dtype=B.dtype)
+        foo(data_nd, out_nd)
+        tvm.testing.assert_allclose(out_nd.numpy(), out_npy)
 
+    for target, dev in tvm.testing.enabled_targets():
+        check_device(target, dev)
+        
 def verify_expand_dims(in_shape, out_shape, axis, num_newaxis):
     A = te.placeholder(shape=in_shape, name="A")
     B = topi.expand_dims(A, axis, num_newaxis)
@@ -839,7 +857,12 @@ def verify_trilu(input_shape, upper, k=0):
     for target, dev in tvm.testing.enabled_targets():
         check_device(target, dev)
 
-
+@tvm.testing.uses_gpu
+def test_pixel_shuffle():
+    verify_pixel_shuffle((1, 256, 4, 128), 2)
+    verify_pixel_shuffle((3, 32, 10, 10), 4)
+    verify_pixel_shuffle((2, 98, 6, 6), 7)
+    
 @tvm.testing.uses_gpu
 def test_strided_slice():
     verify_strided_slice((3, 4, 3), [0, 0, 0], [4, -5, 4], [1, -1, 2])


### PR DESCRIPTION
Model failed in TVM compilation with the following error

``` AssertionError: pixel_shuffle doesn't have an FTVMStrategy registered. You can register one in python with `tvm.relay.op.register_strategy ```