### PR TITLE
Define input as relay constant if "constant" is in the tensor name

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -7203,7 +7203,7 @@ class GraphProto:
             if self._freeze_params:
                 self._nodes[init_tensor.name] = _expr.const(array)
             else:
-                if (
+                if "constant" in init_tensor.name.lower() or (
                     "weight" not in init_tensor.name
                     and "bias" not in init_tensor.name
                     and ("int" in array.dtype or "bool" in array.dtype)


### PR DESCRIPTION
In relay, resize2d can have the scales defined by an input, if this input is not a constant the output shape of the resize2d will be dynamic.