### PR TITLE
Refactor Where operator to avoid generation of NaN tensors

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -3525,14 +3525,21 @@ class Where(OnnxOpConverter):
 
     @classmethod
     def _impl_v9(cls, inputs, attr, params):
+        
+        condition= inputs[0]
+        
+        condition = _op.cast(condition, "float32")
+        condition = _op.abs(condition)
+        condition = _op.clip(condition, 0, 1.0)
+        condition = _op.cast(_op.greater(condition, _expr.const(0, "float32")), "float32")
+
         # Handle -inf/inf values for where operator
         if isinstance(inputs[1], _expr.Constant) and list(analysis.free_vars(inputs[1])) == []:
             val = infer_value(inputs[1], {}).numpy()
-            if val.shape == ():
+            if val.shape == () and np.isinf(val):
                 val = np.sign(val) * 1e4
                 inputs[1] = _expr.const(val)
-        
-        return _op.where(*inputs)
+        return _op.where(condition, inputs[1], inputs[2])
 
 
 class Or(Elemwise):


### PR DESCRIPTION
In pybuda where op is decomposed in a below way

```
elif type == "where":

    condition = inputs[0]
    x = inputs[1]
    y = inputs[2]
    one = dc.tensor(torch.ones((1,)))
    not_condition = dc.op("subtract", [one, condition])

    t0 = dc.op("multiply", [condition, x])
    t1 = dc.op("multiply", [not_condition, y])

    add = dc.op("add", [t0, t1])
    dc.fuse(add)
```

In some cases, mask tensor(inputs[0]) may contain values (example : 3.4028234663852886e+38 -> torch.finfo(torch.float32).min  -> highest representable value for a float32 ) other than 0s and 1s. subtraction of even very small values to this type of mask values should generate -infinity values which will lead to NaN tensor. To avoid that,

- **Added preprocessing steps to convert condition(mask) into binary tensor:**
  - Cast the condition to float32.
  - Applied absolute value and clipped it between 0 and 1.0.
  - Converted the condition to binary (0 or 1) by comparing it to 0.
  
Fill values are getting replaced with ±1e4 without checking whether it is inf/-inf or not. To avoid that,
  
 - **Enhanced the handling of -inf/inf values in the fill value** 
    - Added a condition to check if the value is infinity/ -Infinity .If it is true, then only replacement done with ±1e4 based on the sign.
