### PR TITLE
Erasing casting all floats on input and output to float32

### DIFF
--- a/python/tvm/contrib/pybuda_utils.py
+++ b/python/tvm/contrib/pybuda_utils.py
@@ -59,9 +59,6 @@ def extract_framework_model_outputs(
             
             framework_outputs = flatten_outputs(framework_outputs)
 
-        framework_outputs = (
-            act.float() if torch.is_floating_point(act) else act for act in framework_outputs
-        )
         framework_outputs = [x.detach().numpy() for x in framework_outputs]
 
     elif framework == "tensorflow":
@@ -165,9 +162,6 @@ def extract_flatten_inputs(framework: str, model, inputs, input_names=[]):
         flattened_inputs, flattened_input_names, flattened_name_map = flatten_inputs(
             inputs, input_names
         )
-        flattened_inputs = [
-            inp.float() if torch.is_floating_point(inp) else inp for inp in flattened_inputs
-        ]
 
     elif framework == "tensorflow":
         # The tensorflow trace automatically flattens inputs


### PR DESCRIPTION
Erasing these lines since they cast all tensors from any float to float32. This bug was hidden in pybuda because we hadn't used third return value of the method 
`translated_modules, translated_device_types, _ = generate_pybuda_module(module, pt_inputs, compiler_cfg, module.name, verify_cfg)`

This third parameter is actualy translated_inputs, which had its data format changed by tvm in these lines.

@nvukobratTT do you maybe know why we did this? It doesn't seem desirable. 