### PR TITLE
Remove lowering of `squeeze`/`unsqueeze`

### DIFF
--- a/python/tvm/relay/op/contrib/forge/forge_passes.py
+++ b/python/tvm/relay/op/contrib/forge/forge_passes.py
@@ -1813,7 +1813,6 @@ class LowerAdaptiveMaxPool(DFPatternCallback):
             padding=padding,
         )
 
-
 class LowerSqueezeToReshape(DFPatternCallback):
     def __init__(self):
         super().__init__(require_type=True, rewrite_once=True)
@@ -2047,7 +2046,6 @@ class ConvertExpandDimsToReshape(DFPatternCallback):
         target_shape = list(pre.checked_type.shape)
 
         return tvm.relay.reshape(act, newshape=target_shape)
-
 
 class DecomposeRepeat(DFPatternCallback):
     def __init__(self):
@@ -3882,10 +3880,10 @@ def run_forge_compile_passes(relay_module, params=None, inputs=None, target=None
             LowerAdaptiveMaxPool(),
             EnsureKeepdims(),
             SimplifyTransposeReshape(),
-            LowerSqueezeToReshape(),
+            # LowerSqueezeToReshape(),
             PopulateTransposeAxes(),
             PopulateStridedSliceAxes(),
-            ConvertExpandDimsToReshape(),
+            # ConvertExpandDimsToReshape(),
             DecomposeMultiAxisMean(),
             DecomposeMultiAxisSum(),
             DecomposeMultiAxisBroadcast(),


### PR DESCRIPTION
Remove lowering of squeeze/unsqueeze