### PR TITLE
Map aten::remainder to tvm's mod instead of floor_mod

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -4622,7 +4622,7 @@ class PyTorchOpConverter:
             "aten::floor_divide": self.make_elemwise("floor_divide"),
             "aten::true_divide": self.make_elemwise("divide"),
             "aten::fmod": self.make_elemwise("trunc_mod"),
-            "aten::remainder": self.make_elemwise("floor_mod"),
+            "aten::remainder": self.make_elemwise("mod"),
             "aten::addcdiv": self.addcdiv,
             "aten::addcmul": self.addcmul,
             "aten::ones": self.ones,


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-forge-fe/issues/517
Fixes https://github.com/tenstorrent/tt-forge-fe/issues/710

TTNN directly supports remainder op. Since TVM doesn't have remainder op, aten::remainder is mapped to tvm's [mod](https://tvm.apache.org/docs/reference/api/python/relax/op.html?highlight=mod#tvm.relax.op.mod) op and this will be mapped to Remainder op in Forge