### PR TITLE
Updated verifyConfig (deprecated)

### DIFF
--- a/python/tvm/contrib/forge_compile.py
+++ b/python/tvm/contrib/forge_compile.py
@@ -338,7 +338,7 @@ def compile_pytorch_for_forge(torchmod, *inputs, graph_name, compiler_cfg, verif
             framework="pytorch",
             model=torchmod,
             inputs=inputs,
-            verify_cfg=verify_cfg,
+            verify_tvm_compile=verify_cfg.verify_tvm_compile,
         )
 
         # (Temporary): Remove when forge supports dropout
@@ -548,7 +548,7 @@ def compile_onnx_for_forge(onnx_mod, path, *inputs, graph_name, compiler_cfg, ve
         framework="onnx",
         model=onnx_mod,
         inputs=inputs,
-        verify_cfg=verify_cfg,
+        verify_tvm_compile=verify_cfg.verify_tvm_compile,
         path=path,
         input_dict=input_dict,
     )
@@ -590,7 +590,7 @@ def compile_tflite_for_forge(module, path, *inputs, graph_name, compiler_cfg, ve
         framework="tflite",
         model=module,
         inputs=inputs,
-        verify_cfg=verify_cfg,
+        verify_tvm_compile=verify_cfg.verify_tvm_compile,
         path=path,
     )
 
@@ -689,7 +689,7 @@ def compile_jax_for_forge(jaxmodel, *inputs, graph_name, compiler_cfg, verify_cf
         framework="jax",
         model=jaxmodel,
         inputs=inputs,
-        verify_cfg=verify_cfg,
+        verify_tvm_compile=verify_cfg.verify_tvm_compile,
     )
 
     if compiler_cfg.enable_tvm_jax_freeze_large_model:
@@ -775,7 +775,7 @@ def compile_tf_for_forge(tfmod, *inputs, graph_name, compiler_cfg, verify_cfg=No
         framework="tensorflow",
         model=tfmod,
         inputs=inputs,
-        verify_cfg=verify_cfg,
+        verify_tvm_compile=verify_cfg.verify_tvm_compile,
     )
 
     # Trace module & get graph definition

--- a/python/tvm/contrib/forge_utils.py
+++ b/python/tvm/contrib/forge_utils.py
@@ -13,7 +13,6 @@ from transformers.modeling_outputs import ModelOutput
 
 import tvm
 from tvm.relay import ExprVisitor
-from forge.verify.config import VerifyConfig
 from forge.config import CompilerConfig
 from forge.tvm_utils import flatten_inputs, flatten_structured_output
 from forge.tensor import to_pt_tensors
@@ -24,13 +23,13 @@ def extract_framework_model_outputs(
     framework: str, 
     model, 
     inputs, 
-    verify_cfg: VerifyConfig, 
+    verify_tvm_compile: bool = False, 
     path=None,
     input_dict={},
 ):
     framework_outputs = []
 
-    if verify_cfg is None or not verify_cfg.verify_tvm_compile:
+    if verify_tvm_compile:
         return framework_outputs
 
     if framework == "pytorch":


### PR DESCRIPTION
Updated `verifyConfig` import from `tvm` as it is `forge` component which is **deprecated** and we are working on a new version.