### PR TITLE
Add support for the reflect padding mode in Conv2D operation

### DIFF
--- a/python/tvm/relay/op/contrib/forge/forge_passes.py
+++ b/python/tvm/relay/op/contrib/forge/forge_passes.py
@@ -156,9 +156,16 @@ class FuseConvAndPoolPadding(DFPatternCallback):
         pad_width = pad.attrs.pad_width
         top_pad, bottom_pad = pad_width[-2]
         left_pad, right_pad = pad_width[-1]
+        
+        pad_mode = pad.attrs.pad_mode
+        
+        if pad_mode == "constant":
+            padding = [top_pad, left_pad, bottom_pad, right_pad]
 
-        padding = [top_pad, left_pad, bottom_pad, right_pad]
-
+        if pad_mode == "reflect":
+            act = tvm.relay.op.nn.pad(act, pad_width, pad_mode="reflect")
+            padding = [0,0,0,0]
+        
         op_attrs = {**conv_pool.attrs}
         op_attrs["padding"] = padding
 


### PR DESCRIPTION
## Summary :

- Data mismatch observed between framework and Forge codegen in Monodepth2 variants due to incorrect handling of [reflect mode](https://github.com/nianticlabs/monodepth2/blob/b676244e5a1ca55564eb5d16ab521a48f823af31/layers.py#L128) in conv2d padding. 

## Logs:

- [monodepth2_all_variants_before_fix.log](https://github.com/user-attachments/files/18098443/dec11_monodepth2_monodepth_all_v_after_before_fix.log)
- [monodepth2_all_variants_after_fix.log](https://github.com/user-attachments/files/18098444/dec11_monodepth2_monodepth_all_v_after_fix.log)


