### PR TITLE
Add embedding weight cast from float32 to bfloat16

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2700,7 +2700,10 @@ class PyTorchOpConverter:
             #  exposes a few bugs in tt-mlir https://github.com/tenstorrent/tt-mlir/issues/1215
             logger.warning("Casting input indices of embedding op from {} to int32", indicies_dtype)
             indices = tvm.relay.cast(indices, "int32")
-        return _op.embedding(weight, indices, axis=0)
+        # cast the weight to bfloat16 if it is float32
+        if weight.type_annotation.dtype == "float32":
+            weight = tvm.relay.cast(weight, "bfloat16")
+        return tvm.relay.cast(_op.embedding(weight, indices, axis=0), "float32")
 
     def embedding_bag(self, inputs, input_types):
 


### PR DESCRIPTION
Since ttnn only supports weight of embedding to be bfloat16, cast is introduced as a temporary solution until tt-mlir supports casting of embedding weight in workaround pass (https://github.com/tenstorrent/tt-mlir/pull/1657). This enables llama embedding to work.