### PR TITLE
Add support for nan_to_num, atan2 & bitwise_or op

### DIFF
--- a/python/tvm/relay/op/contrib/forge/forge_passes.py
+++ b/python/tvm/relay/op/contrib/forge/forge_passes.py
@@ -3257,10 +3257,13 @@ class ConvertIsNaN(DFPatternCallback):
         
         data = pre_node_map[self.data][0]
         
-        cond = tvm.relay.equal(data, tvm.relay.const(np.nan, dtype="float32"))
-        where = tvm.relay.where(cond, tvm.relay.const(True), tvm.relay.const(False))
+        # NaN (Not a Number) is the only value in floating-point arithmetic that is not equal to itself.
+        # So, comparing data with itself will return True if data is NaN, and False otherwise.
+        # This condition is used to identify NaN values in the data tensor.
         
-        return where
+        cond = tvm.relay.not_equal(data, data)
+        
+        return cond 
     
     
 class RemoveRedundantBinaryStacks(DFPatternCallback):


### PR DESCRIPTION
## Summary 

- PETR model uses nan_to_num op [here](https://github.com/megvii-research/PETR/blob/f7525f93467a33707ef401c587a52d5e7b34de74/projects/mmdet3d_plugin/models/dense_heads/petr_head.py#L420) & atan2 op [here](https://github.com/megvii-research/PETR/blob/f7525f93467a33707ef401c587a52d5e7b34de74/projects/mmdet3d_plugin/core/bbox/util.py#L65)  
- Support added for those ops. 
- This PR fixes https://github.com/tenstorrent/tt-forge-fe/issues/982 by mapping "aten::bitwise_or_": to "bitwise_or"
- our nan_to_num_decomposition needs isnan. existing decomposition of isnan in forge_passes.py didn't detected NaN values. so updated the decomposition with this logic (a NaN value is not equal to itself) which detects NaN values correctly

## Logs 

- [isnan_before_fix.log](https://github.com/user-attachments/files/18351273/jan8_zz_isnan_before_fix.log)
- [isnan_after_fix.log](https://github.com/user-attachments/files/18351272/jan8_zz_isnan_after_fix.log)
