### PR TITLE
Change decomposition of zeros_like op

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -952,6 +952,8 @@ class PyTorchOpConverter:
             dtype = _convert_dtype_value(inputs[1])
         else:
             dtype = self.default_dtype
+            
+        data = data[0] if isinstance(data, list) else data
         return self.full_impl(data, 0, dtype)
 
     def zero_(self, inputs, input_types):
@@ -960,16 +962,10 @@ class PyTorchOpConverter:
 
     def zeros_like(self, inputs, input_types):
         data = inputs[0]
-        out = _op.zeros_like(data)
-
-        # If the input and the output datatype is different, do a cast
-        if inputs[1] is not None:
-            dtype = _convert_dtype_value(inputs[1])
-        else:
-            dtype = self.default_dtype
-        if input_types[0] not in dtype:
-            out = _op.cast(out, dtype)
-
+        
+        inputs = [[_infer_shape(data)], inputs[1]]
+        out = self.zeros(inputs, input_types[0])
+        
         return out
 
 


### PR DESCRIPTION
Model faces `AttributeError: <class 'tvm.ir.op.Op'> has no attribute name_hint` and zeros op is binded as global_var and passed as input params to tvmgen_default_forge_main as linked in the log below
[detr.log](https://github.com/user-attachments/files/18434839/detr.log)

The zeros_like operation in TVM was originally implemented by mapping it directly to the corresponding tvm.zeros_like function, while the new_zeros and zeros operations were mapped to the full operation as mentioned [here](https://github.com/tenstorrent/tt-tvm/blob/c566aae4cee1ce36bcc029957bbc8c51b477ea12/python/tvm/relay/frontend/pytorch.py#L955). However, this inconsistency caused the zeros operation to remain unbounded during the partition_graph transformation in TVM.

To address this issue, the decomposition of the zeros_like operation was modified to be mapped to zeros op to align with the zeros_like op being mapped finally to the full operation instead. This ensures consistency and resolves the issue of the zeros operation being unbounded during the transformation.