### PR TITLE
[installation] fix llvm config

### DIFF
--- a/cmake/utils/FindLLVM.cmake
+++ b/cmake/utils/FindLLVM.cmake
@@ -111,6 +111,14 @@ macro(find_llvm use_llvm)
       message(FATAL_ERROR "Fatal error executing: ${LLVM_CONFIG} --libdir")
     endif()
     message(STATUS "LLVM libdir: ${__llvm_libdir}")
+    execute_process(COMMAND ${LLVM_CONFIG} --cmakedir
+      RESULT_VARIABLE __llvm_exit_code
+      OUTPUT_VARIABLE __llvm_cmakedir
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT "${__llvm_exit_code}" STREQUAL "0")
+      message(FATAL_ERROR "Fatal error executing: ${LLVM_CONFIG} --cmakedir")
+    endif()
+    message(STATUS "LLVM cmakedir: ${__llvm_cmakedir}")
     # map prefix => $
     # to handle the case when the prefix contains space.
     string(REPLACE ${__llvm_prefix} "$" __llvm_cxxflags ${__llvm_cxxflags_space})
@@ -165,6 +173,7 @@ macro(find_llvm use_llvm)
         find_package(ZLIB REQUIRED)
         list(APPEND LLVM_LIBS "ZLIB::ZLIB")
       elseif("${__flag}" STREQUAL "-lzstd" OR ("${__flag}" STREQUAL "zstd.dll.lib"))
+        list(APPEND CMAKE_MODULE_PATH "${__llvm_cmakedir}")
         find_package(zstd REQUIRED)
         if (TARGET "zstd::libzstd_static")
           message(STATUS "LLVM links against static zstd")

--- a/install.sh
+++ b/install.sh
@@ -11,15 +11,6 @@ echo $FORGE_ROOT
 cd $FORGE_ROOT
 export TVM_HOME=$FORGE_ROOT/third_party/tvm
 
-# Download / untar LLVM
-cd $FORGE_ROOT/third_party
-if [ ! -d "$FORGE_ROOT/third_party/llvm" ]; then
-  wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
-  LLVM_TAR=$FORGE_ROOT/third_party/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
-  LLVM_DIR=$FORGE_ROOT/third_party/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04
-  tar -xf $LLVM_TAR && mv $LLVM_DIR $FORGE_ROOT/third_party/llvm && rm -f $LLVM_TAR
-fi
-
 cd $TVM_HOME
 git submodule init; git submodule update
 
@@ -27,8 +18,26 @@ mkdir -p build
 cp $TVM_HOME/cmake/config.cmake $TVM_HOME/build
 cd $TVM_HOME/build
 
-# Link the LLVM thats just been downloaded
-LLVM_LINK=$FORGE_ROOT/third_party/llvm/bin/llvm-config
+if [[ -n $LLVM_CONFIG_CMD && -e $LLVM_CONFIG_CMD ]]; then
+    # pass in through environment variable
+    echo Using "$LLVM_CONFIG_CMD" as LLVM_LINK
+    LLVM_LINK="$LLVM_CONFIG_CMD"
+elif [[ -e /usr/bin/llvm-config-17 ]]; then
+    # should be present; llvm-17 is included in our ubuntu 22.04 images
+    echo Using /usr/bin/llvm-config-17 as LLVM_LINK
+    LLVM_LINK=/usr/bin/llvm-config-17
+else
+    # Download / untar LLVM
+    echo Downloading llvm 13
+    if [ ! -d "$PYBUDA_ROOT/third_party/llvm" ]; then
+        wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
+        LLVM_TAR=$PYBUDA_ROOT/third_party/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
+        LLVM_DIR=$PYBUDA_ROOT/third_party/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04
+        tar -xf $LLVM_TAR && mv $LLVM_DIR $PYBUDA_ROOT/third_party/llvm && rm -f $LLVM_TAR
+    fi
+    # Link the LLVM thats just been downloaded
+    LLVM_LINK=$PYBUDA_ROOT/third_party/llvm/bin/llvm-config
+fi
 sed -i "s#/usr/bin/llvm-config#$LLVM_LINK#g" $TVM_HOME/build/config.cmake
 
 if [[ "$TVM_BUILD_CONFIG" == "debug" ]]; then


### PR DESCRIPTION
(copied from https://github.com/tenstorrent/tt-forge-fe/pull/1185)

### Problem description
1. Each tvm installation downloads llvm 13.0.0 and extracts the package, but only uses the `llvm-config` binary;
2. The downloaded version is old (released Sept. 2021), and was only for ubuntu 20.04, while forge by default works on ubuntu 22.04.

### What's changed
Our forge docker image includes llvm-config-17. We only need to pick up [a fix in apache-tvm](https://github.com/apache/tvm/commit/3b8d1a831dca3c9165168365e7e77c4e7f6746c9), and to add the necessary packages in our docker image.

I've also added the option to specify a custom llvm-config in case we want to use another version, but so far I haven't run into any issue with llvm-config-17.