### PR TITLE
[Relay] Decompose meshgrid using explicit broadcasting

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2848,7 +2848,8 @@ class PyTorchOpConverter:
 
     def meshgrid(self, inputs, input_types):
         data = inputs[0]
-        return _op.meshgrid(data, indexing="ij")
+        indexing = inputs[1] if len(inputs) > 1 else "ij"
+        return _op.meshgrid(data,indexing)
 
     def nms(self, inputs, input_types):
         boxes = inputs[0]


### PR DESCRIPTION
## Summary 

- The [PETR model](https://github.com/tenstorrent/tt-forge-fe/issues/955) requires [Meshgrid3D](https://github.com/megvii-research/PETR/blob/f7525f93467a33707ef401c587a52d5e7b34de74/projects/mmdet3d_plugin/models/dense_heads/petr_head.py#L300C30-L300C44). This PR adds support for Meshgrid using explicit broadcasting.

