### PR TITLE
Add support for record execution phase and stage

### DIFF
--- a/python/tvm/relay/op/contrib/forge/forge.py
+++ b/python/tvm/relay/op/contrib/forge/forge.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 import torch
+from forge.execution_tracker import ExecutionStage, record_execution_phase_and_stage
 
 import tvm
 from tvm import relay
@@ -1092,8 +1093,11 @@ def compile_for_forge(relay_module, graph_name, target='llvm', params=None, inpu
 
         relay_module = run_relay_compile_passes(relay_module)
         dump_graph(relay_module, graph_name, "after_relay_passes")
+        record_execution_phase_and_stage(ExecutionStage.TVM_RELAY_IR_TRANSFORM)
+
         compiled_relay_module = run_forge_compile_passes(relay_module, params, inputs, target, framework_outputs, verify_cfg)
         dump_graph(compiled_relay_module, graph_name, "after_forge_passes")
+        record_execution_phase_and_stage(ExecutionStage.TVM_PATTERN_CALLBACKS)
         
         # Integer comparisons may lead to incorrect results on HW
         warn_of_int_comparisons(compiled_relay_module)


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-forge-fe/issues/1171

The PR will enable us to record execution phase and stage in the TVM compilation and for now it will record execution phase and stage for PyTorch, Tenorflow, TFLite and Onnx Framework