### PR TITLE
Add initial support for PaddlePaddle

### DIFF
--- a/python/tvm/contrib/forge_compile.py
+++ b/python/tvm/contrib/forge_compile.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import inspect
-from forge.tensor import to_tf_tensors, to_pt_tensors, pt_to_paddle_tensors
+from forge.tensor import to_tf_tensors, to_pt_tensor, to_pt_tensors, pt_to_paddle_tensors
 from forge.tvm_utils import flatten_inputs, flatten_structured_output
 import paddle
 import torch
@@ -1056,7 +1056,7 @@ def format_tvm_graph_weights(inputs, module, compiler_cfg, framework=None):
         named_buffers = dict(module.named_buffers())
         paddle_weights.update(named_buffers)
         named_params = dict(module.named_parameters())
-        weights = {(named_params[key].name if key in named_params else key): (value, named_params[key].trainable if key in named_params else False) for key, value in paddle_weights.items()}
+        weights = {value.name : (to_pt_tensor(value), value.trainable if key in named_params else False) for key, value in paddle_weights.items()}
       
     elif framework == "tensorflow":
         weights = {weight.name: (torch.Tensor((tf.cast(weight.value(), tf.float32) if weight.value().dtype.is_floating else weight.value()).numpy()), True) for weight in module.weights}

--- a/python/tvm/contrib/forge_compile.py
+++ b/python/tvm/contrib/forge_compile.py
@@ -435,7 +435,7 @@ def compile_paddle_for_forge(paddlemod, *inputs, graph_name, compiler_cfg, verif
 
         # parameter names are changed during save and load
         # original_param_names = sorted([param.name for param in paddlemod.parameters()])
-        original_param_names = sorted([name for name, _ in paddlemod.state_dict().items()])
+        original_param_names = sorted([param.name for param in paddlemod.parameters()])
         new_param_names = sorted([param.name for param in loaded_model.parameters()])
         param_name_lookup = {new: old for new, old in zip(new_param_names, original_param_names)}
 
@@ -1056,8 +1056,8 @@ def format_tvm_graph_weights(inputs, module, compiler_cfg, framework=None):
         paddle_weights.update(named_buffers)
         named_params = dict(module.named_parameters())
         
-        # weights = {(named_params[key].name if key in named_params else key): (value, named_params[key].trainable if key in named_params else False) for key, value in paddle_weights.items()}
-        weights = {key: (value, named_params[key].trainable if key in named_params else False) for key, value in paddle_weights.items()}
+        weights = {(named_params[key].name if key in named_params else key): (value, named_params[key].trainable if key in named_params else False) for key, value in paddle_weights.items()}
+        # weights = {key: (value, named_params[key].trainable if key in named_params else False) for key, value in paddle_weights.items()}
 
     elif framework == "tensorflow":
         weights = {weight.name: (torch.Tensor((tf.cast(weight.value(), tf.float32) if weight.value().dtype.is_floating else weight.value()).numpy()), True) for weight in module.weights}

--- a/python/tvm/contrib/forge_utils.py
+++ b/python/tvm/contrib/forge_utils.py
@@ -170,7 +170,10 @@ def extract_flatten_inputs(framework: str, model, inputs, input_names=[]):
             for inp in paddle_inputs
         ]
         flattened_inputs, _, _ = flatten_inputs(inputs)
-        flattened_input_names = list(inspect.signature(model.forward).parameters.keys())
+        if hasattr(model, '_input_args_names'):
+            flattened_input_names = model._input_args_names
+        else:
+            flattened_input_names = list(inspect.signature(model.forward).parameters.keys())
         flattened_name_map = None
         
     elif framework == "tensorflow":

--- a/python/tvm/contrib/forge_utils.py
+++ b/python/tvm/contrib/forge_utils.py
@@ -32,7 +32,7 @@ def extract_framework_model_outputs(
     if verify_tvm_compile:
         return framework_outputs
 
-    if framework == "pytorch":
+    if framework == "pytorch" or framework == "paddle":
         assert model.training == False
 
         framework_outputs = model(*inputs)
@@ -161,7 +161,12 @@ def extract_flatten_inputs(framework: str, model, inputs, input_names=[]):
         flattened_inputs, flattened_input_names, flattened_name_map = flatten_inputs(
             inputs, input_names
         )
-
+    elif framework == "paddle":
+        flattened_inputs, _, _ = flatten_inputs(inputs)
+        flattened_input_names = None
+        flattened_name_map = None
+        input_structure = None
+        
     elif framework == "tensorflow":
         # The tensorflow trace automatically flattens inputs
         flattened_inputs, _, _ = flatten_inputs(inputs)
@@ -183,7 +188,7 @@ def extract_flatten_inputs(framework: str, model, inputs, input_names=[]):
 
 
 def construct_tvm_ir(framework: str, model, tvm_mod, params, compiler_cfg: CompilerConfig):
-    if framework == "pytorch":
+    if framework == "pytorch" or framework == "paddle":
         param_name_lookup = {}
 
         if not compiler_cfg.enable_tvm_constant_prop:


### PR DESCRIPTION
Add initial support for compiling PaddlePaddle modules, following the PyTorch approach for module compilation.

The main logic is in `compile_paddle_for_forge` -  preparing inputs and outputs and extracting `paddle.nn.TranslatedLayer` needed for TVM Relay. Paddle models is a `TranslayedLayer` if it is loaded from files, otherwise is a `paddle.nn.Layer`. 

The rest follows the PyTorch workflow.