### PR TITLE
Removed DictType from TVM

### DIFF
--- a/include/tvm/ir/type.h
+++ b/include/tvm/ir/type.h
@@ -1,6 +1,3 @@
-// SPDX-FileCopyrightText: © 2019-2023 The Apache Software Foundation © 2024 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -372,34 +369,6 @@ class TupleTypeNode : public TypeNode {
 };
 
 /*!
- * \brief The type of dictionary of str, value.
- * \sa DictType
- */
-class DictTypeNode : public TypeNode {
- public:
-  /*! \brief the key (String) and type of each value */
-  Array<String> keys;
-  Array<Type> values;
-
-  DictTypeNode() {}
-
-  void VisitAttrs(AttrVisitor* v) {
-    v->Visit("keys", &keys);
-    v->Visit("values", &values);
-    v->Visit("span", &span);
-  }
-
-  bool SEqualReduce(const DictTypeNode* other, SEqualReducer equal) const {
-    return equal(keys, other->keys) && equal(values, other->values);
-  }
-
-  void SHashReduce(SHashReducer hash_reduce) const { hash_reduce(keys); }
-
-  static constexpr const char* _type_key = "DictType";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DictTypeNode, TypeNode);
-};
-
-/*!
  * \brief Managed reference to TupleTypeNode.
  * \sa TupleTypeNode.
  */
@@ -419,29 +388,6 @@ class TupleType : public Type {
   TVM_DLL TupleType static Empty();
 
   TVM_DEFINE_OBJECT_REF_METHODS(TupleType, Type, TupleTypeNode);
-};
-
-/*!
- * \brief Managed reference to DictTypeNode.
- * \sa DictTypeNode.
- */
-class DictType : public Type {
- public:
-  /*!
-   * \brief Constructor
-   * \param keys keys of the dict.
-   * \param values values of the dict
-   * \param span The span of the type.
-   */
-  TVM_DLL explicit DictType(Array<String> keys, Array<Type> values, Span span = Span());
-
-  /*!
-   * \brief Create an empty Dict type that constains nothing.
-   * \return A empty Dict type.
-   */
-  TVM_DLL DictType static Empty();
-
-  TVM_DEFINE_OBJECT_REF_METHODS(DictType, Type, DictTypeNode);
 };
 
 /*!

--- a/include/tvm/relay/type.h
+++ b/include/tvm/relay/type.h
@@ -54,7 +54,6 @@ using TypeVarNode = tvm::TypeVarNode;
 using GlobalTypeVar = tvm::GlobalTypeVar;
 using GlobalTypeVarNode = tvm::GlobalTypeVarNode;
 using TupleType = tvm::TupleType;
-using DictType = tvm::DictType;
 using TupleTypeNode = tvm::TupleTypeNode;
 using TypeConstraint = tvm::TypeConstraint;
 using TypeConstraintNode = tvm::TypeConstraintNode;

--- a/python/tvm/ir/type.py
+++ b/python/tvm/ir/type.py
@@ -174,20 +174,6 @@ class TupleType(Type):
     def __init__(self, fields):
         self.__init_handle_by_constructor__(_ffi_api.TupleType, fields)
 
-@tvm._ffi.register_object("DictType")
-class DictType(Type):
-    """The type of dict values.
-
-    Parameters
-    ----------
-    keys : List[str]
-        The keys in the dict
-    values : List[Type]
-        The values in the dict
-    """
-
-    def __init__(self, keys, values):
-        self.__init_handle_by_constructor__(_ffi_api.DictType, keys, values)
 
 @tvm._ffi.register_object("TypeConstraint")
 class TypeConstraint(Type):

--- a/src/ir/type.cc
+++ b/src/ir/type.cc
@@ -1,6 +1,3 @@
-// SPDX-FileCopyrightText: © 2019-2023 The Apache Software Foundation © 2024 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -114,22 +111,6 @@ TVM_REGISTER_NODE_TYPE(TupleTypeNode);
 
 TVM_REGISTER_GLOBAL("ir.TupleType").set_body_typed([](Array<Type> fields) {
   return TupleType(fields);
-});
-
-DictType::DictType(Array<String> keys, Array<Type> values, Span span) {
-  ObjectPtr<DictTypeNode> n = make_object<DictTypeNode>();
-  n->keys = std::move(keys);
-  n->values = std::move(values);
-  n->span = std::move(span);
-  data_ = std::move(n);
-}
-
-DictType DictType::Empty() { return DictType(Array<String>(), Array<Type>()); }
-
-TVM_REGISTER_NODE_TYPE(DictTypeNode);
-
-TVM_REGISTER_GLOBAL("ir.DictType").set_body_typed([](Array<String> keys, Array<Type> values) {
-  return DictType(keys, values);
 });
 
 IncompleteType::IncompleteType(TypeKind kind, Span span) {


### PR DESCRIPTION
Removed DictType from TVM as it was initially added by us.

This is corresponding TVM [PR](https://github.com/tenstorrent/tt-tvm/pull/69).