### PR TITLE
Fix convert_lookup_table op for Paddle

### DIFF
--- a/python/tvm/relay/frontend/paddlepaddle.py
+++ b/python/tvm/relay/frontend/paddlepaddle.py
@@ -1166,6 +1166,8 @@ def convert_lookup_table(g, op, block):
     weights = g.get_node(op.input("W")[0])
     if padding_idx != -1:
         if op.input("W")[0] in g.get_params():
+            # TVM NDArray does not support item assignment like weights[padding_idx] = 0.0,
+            # so we convert to numpy, modify the values, then convert back to TVM NDArray.
             weights_np = g.get_params(op.input("W")[0]).asnumpy()
             weights_np[padding_idx] = 0.0
             weights = tvm.nd.array(weights_np)

--- a/python/tvm/relay/frontend/paddlepaddle.py
+++ b/python/tvm/relay/frontend/paddlepaddle.py
@@ -1166,8 +1166,9 @@ def convert_lookup_table(g, op, block):
     weights = g.get_node(op.input("W")[0])
     if padding_idx != -1:
         if op.input("W")[0] in g.get_params():
-            weights = g.get_params(op.input("W")[0])
-            weights[padding_idx] = 0.0
+            weights_np = g.get_params(op.input("W")[0]).asnumpy()
+            weights_np[padding_idx] = 0.0
+            weights = tvm.nd.array(weights_np)
             weights = _expr.const(weights)
         else:
             shape, infered = try_infer_value(shape_of(weights), g.get_params())


### PR DESCRIPTION
Casted `weights` to numpy array so it can be indexed correctly to fix the error that occurred while compiling language models from paddlenlp library.