### PR TITLE
Add support for resolve_neg, resolve_conj ops

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -4793,6 +4793,17 @@ class PyTorchOpConverter:
         result = tvm.relay.add(atan_res, correction)
         
         return result
+    
+    def resolve_conj(self, inputs, input_types):
+        # TVM doesn't track conjugate/negate flags; input is already materialized.
+        # Returning the input directly is appropriate for resolve_conj.
+        return inputs
+    
+    def resolve_neg(self, inputs, input_types):
+        # TVM doesn't track conjugate/negate flags; input is already materialized.
+        # Returning the input directly is appropriate for resolve_neg.
+        return inputs
+        
 
     # Operator mappings
     def create_convert_map(self):
@@ -5098,6 +5109,8 @@ class PyTorchOpConverter:
             "aten::lift_fresh": self.identity,
             "aten::nan_to_num": self.nan_to_num,
             "aten::atan2": self.atan2,
+            "aten::resolve_conj": self.resolve_conj,
+            "aten::resolve_neg": self.resolve_neg,
         }
 
     def update_convert_map(self, custom_map):


### PR DESCRIPTION
## Summary 

- In the `microsoft/Phi-3.5-vision-instruct` model, [this](https://huggingface.co/microsoft/Phi-3.5-vision-instruct/blob/main/modeling_phi3_v.py#L229) tensor to list conversion triggers `aten::resolve_conj` and `aten::resolve_neg` because PyTorch must resolve all tensor flags (like conjugate and negative) before performing a full list conversion. 
- Since TVM doesn't yet support these ops natively, they cause a  `NotImplementedError: The following operators are not implemented: ['aten::resolve_conj', 'aten::resolve_neg']` during frontend conversion. 
- In PyTorch, [torch.resolve_conj](https://pytorch.org/docs/stable/generated/torch.resolve_conj.html) and [torch.resolve_neg](https://pytorch.org/docs/stable/generated/torch.resolve_neg.html) are used to resolve the conjugate and negative flags on tensors.These flags are metadata typically for lazy computation
- However, in TVM, there is no concept of these lazy flags—TVM operates on concrete tensor values during the graph conversion. 
- By the time these ops  are encountered during conversion, the actual tensor values have already been materialized. That means any conjugate or negative logic has either been already applied 
- This is why returning `inputs` directly here is sufficient. 

