### PR TITLE
Fix nonzero_numpy conversion for as_tuple=True

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3016,7 +3016,7 @@ class PyTorchOpConverter:
         return ret
 
     def nonzero_numpy(self, inputs, input_types):
-        return self.nonzero(inputs, input_types, is_numpy_style=False)
+        return self.nonzero(inputs, input_types, is_numpy_style=True)
 
     def scatter(self, inputs, input_types):
         assert len(inputs) == 4 or len(inputs) == 5, (


### PR DESCRIPTION
### Issue 

After jit.trace , torch.nonzero(x,as_tuple=True) is mapped to **aten::nonzero_numpy**. It is treated as [argwhere(%ip)](https://github.com/tenstorrent/tt-tvm/blob/0eff2cc96ebd3fadedf3e7603b789a6319f4a3c5/python/tvm/relay/frontend/pytorch.py#L3013). But this results in a CallNode, not a tuple, and so the call to _unpack_tuple() fails because CallNode doesn’t have a type_annotation, throwing

```
AttributeError: <class 'tvm.relay.expr.Call'> has no attribute type_annotation
```

### Root cause 

The nonzero_numpy implementation internally [calls](https://github.com/tenstorrent/tt-tvm/blob/0eff2cc96ebd3fadedf3e7603b789a6319f4a3c5/python/tvm/relay/frontend/pytorch.py#L3018): `self.nonzero(inputs, input_types, is_numpy_style=False)`.
But this is incorrect if as_tuple=True in PyTorch, because:

- as_tuple=True requires [unbinding the result](https://github.com/tenstorrent/tt-tvm/blob/0eff2cc96ebd3fadedf3e7603b789a6319f4a3c5/python/tvm/relay/frontend/pytorch.py#L3015C20-L3015C34) (i.e., breaking a tuple of coordinates into individual tensors along dim=1).
- unbind happen if [is_numpy_style=True](https://github.com/tenstorrent/tt-tvm/blob/0eff2cc96ebd3fadedf3e7603b789a6319f4a3c5/python/tvm/relay/frontend/pytorch.py#L3014).
- So with is_numpy_style=False, it just returns a [single argwhere() result](https://github.com/tenstorrent/tt-tvm/blob/0eff2cc96ebd3fadedf3e7603b789a6319f4a3c5/python/tvm/relay/frontend/pytorch.py#L3013C9-L3013C12) as a CallNode, and not a Tuple, causing the _unpack_tuple() to fail.


### Fix

**is_numpy_style** is set to True in nonzero_numpy function to correctly reflect the **as_tuple=True** behavior in torch.nonzero

### Logs

- [non_zero_sanity_before_fix.log](https://github.com/user-attachments/files/19896979/apr24_non_zero_before_fix.log)
- [non_zero_sanity_after_fix.log](https://github.com/user-attachments/files/19896978/apr24_non_zero_after_fix.log)



