### PR TITLE
Fix Failure in zero_ op for symbolic shapes by using full_like fallback

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -955,7 +955,15 @@ class PyTorchOpConverter:
 
     def zero_(self, inputs, input_types):
         data = inputs[0]
-        return self.full_impl(self.infer_shape(data), 0, input_types[0])
+        shape = self.infer_shape(data)
+        
+        # Check if any shape dimension is symbolic (not an int)
+        is_symbolic = any(not isinstance(dim, int) for dim in shape)
+        if is_symbolic:
+            return _op.full_like(data, fill_value=_expr.const(0))
+        else:
+            return self.full_impl(shape, 0, input_types[0])
+
 
     def zeros_like(self, inputs, input_types):
         data = inputs[0]


### PR DESCRIPTION
### Problem description

-  swin_v2_t, swin_v2_s ,swin_v2_b variants in swinv2 model (`forge/test/models/pytorch/vision/swin/test_swin.py:: test_swin_torchvision`) faced below error due to [this](https://github.com/pytorch/vision/blob/fbb4cc54ed521ba912f50f180dc16a213775bf5c/torchvision/models/swin_transformer.py#L178C38-L178C46) operation.

```
E       TVMError: In function relay.op._make.full(0: RelayExpr, 1: Array<IntImm>, 2: DataType) -> RelayExpr: error while converting argument 1: [09:22:01] /proj_sw/user_dev/kkannan/apr27/tt-forge-fe/third_party/tvm/include/tvm/runtime/packed_func.h:1952: InternalError: Check failed: (!checked_type.defined()) is false: Expected Array[IntImm], but got Array[index 0: tir.Any]
```

### Root cause

-  Compiler previously assumed all tensor shapes passed to `zero_()` are static (i.e., known integers). This led to a error when `zero_()` was called on a tensor with symbolic dimensions (e.g., `tir.Any()`), as `relay.op.full()` requires the shape to be a list of `IntImm`(i.e., known integers).

### Fix

- The fix adds a check in the zero_ implementation to detect symbolic shapes (i.e., dimensions not of type int). 
- When symbolic dimensions are detected, it falls back to using relay.op.full_like which copies the shape and dtype from data, and fills it with zero and works even if shape is symbolic. 
- If all dimensions are static, it uses the original full_impl().

### logs

- [sanity_before_fix.log](https://github.com/user-attachments/files/19963884/apr29_zzz_sanities_before_fix.log)
- [sanity_after_fix.log](https://github.com/user-attachments/files/19963883/apr29_zzz_sanities_after_fix.log)
- [swin_before_fix.log](https://github.com/user-attachments/files/19963882/apr29_swin_all_tc_variants_bf_1.log)
- [swin_after_fix.log](https://github.com/user-attachments/files/19963881/apr29_swin_all_tc_variants_af_1.log)


