### PR TITLE
Map concat op and increase recursion limit

### DIFF
--- a/python/tvm/relay/__init__.py
+++ b/python/tvm/relay/__init__.py
@@ -72,7 +72,7 @@ from .transform import memory_plan
 from .parser import parse, parse_expr, fromtext, SpanCheck
 
 # Required to traverse large programs
-setrecursionlimit(10000)
+setrecursionlimit(20000)
 
 # Span
 Span = base.Span

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -4957,6 +4957,7 @@ class PyTorchOpConverter:
             "aten::squeeze": self.squeeze,
             "aten::unsqueeze": self.unsqueeze,
             "aten::cat": self.concatenate,
+            "aten::concat": self.concatenate,
             "aten::slice": self.slice,
             "aten::narrow": self.narrow,
             "aten::split": self.split,


### PR DESCRIPTION
Stable Diffusion xl model faces
`NotImplementedError: The following operators are not implemented: ['aten::concat']`

After mapping this op, model fails with recursion from FlattenInputs during frontend conversion.

Hence recursion limit has been increased to solve this.