### PR TITLE
Properly compute broadcasted batch shape for final reshape in matmul

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2261,10 +2261,13 @@ class PyTorchOpConverter:
 
             # Perform a batch matmul.
             output = _op.nn.batch_matmul(a, b)
+            
+            # Compute batch shape for final reshape operation.
+            batch_shape = tuple(max(a, b) for a, b in zip(a_shape[:-2], b_shape[:-2]))  
 
             # Reshape output to original dimensions.
             if need_reshape_output:
-                return _op.reshape(output, [*a_shape[:-2], a_shape[-2], b_shape[-1]])
+                return _op.reshape(output, [*batch_shape, a_shape[-2], b_shape[-1]])
             return output
 
         elif len(a_shape) > 2 and len(b_shape) == 1:


### PR DESCRIPTION
### Problem description 

- OFT model(`forge/test/models/pytorch/vision/oft/test_oft.py`) Faced `InternalError: Check failed: oshape_sum == data_shape_sum (3 vs. 614400) : Input tensor shape(204800,3,1) and reshaped shape(1,1,1,1,3,1) are not compatible!`

### Root cause 

- It is arising from [this](https://github.com/tenstorrent/tt-forge-models/blob/3ef1f8ea483316cfa530eee199151971fafe237d/oft/src/utils.py#L77C18-L77C56) matmul operartion.
- Reshape after batch_matmul always used a_shape[:-2] for the batch shape, ignoring the fact that b_shape's batch dims could be larger. (e.g., `a_shape=(1,1,1,1,3,3) and b_shape=(1,8,160,160,3,1)`) 

### Fix 

- Calculate the output batch shape as the element-wise maximum between a_shape[:-2] and b_shape[:-2] using: `batch_shape = tuple(max(a, b) for a, b in zip(a_shape[:-2], b_shape[:-2]))`
- This ensures the reshape uses the correct broadcasted batch shape, changing the required output shape from (1, 1, 1, 1, 3, 1) to (1, 8, 160, 160, 3, 1)
