### PR TITLE
[build] disable gtest by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ tvm_option(BACKTRACE_ON_SEGFAULT "Install a signal handler to print a backtrace 
 tvm_option(BUILD_STATIC_RUNTIME "Build static version of libtvm_runtime" OFF)
 tvm_option(BUILD_DUMMY_LIBTVM "Build a dummy version of libtvm" OFF)
 tvm_option(USE_PAPI "Use Performance Application Programming Interface (PAPI) to read performance counters" OFF)
-tvm_option(USE_GTEST "Use GoogleTest for C++ sanity tests" AUTO)
+tvm_option(USE_GTEST "Use GoogleTest for C++ sanity tests" OFF)
 tvm_option(USE_CUSTOM_LOGGING "Use user-defined custom logging, tvm::runtime::detail::LogFatalImpl and tvm::runtime::detail::LogMessageImpl must be implemented" OFF)
 tvm_option(USE_ALTERNATIVE_LINKER "Use 'mold' or 'lld' if found when invoking compiler to link artifact" AUTO)
 tvm_option(USE_CCACHE "Use ccache if found when invoking compiler" AUTO)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -419,7 +419,7 @@ set(USE_PAPI OFF)
 #   be enabled, otherwise it will be disabled.
 # Note that cmake will use `find_package` to find GTest. Please use cmake's
 # predefined variables to specify the path to the GTest package if needed.
-set(USE_GTEST AUTO)
+set(USE_GTEST OFF)
 
 # Enable using CUTLASS as a BYOC backend
 # Need to have USE_CUDA=ON


### PR DESCRIPTION
Since we are not running these tests anyway, disable building them by default.