### PR TITLE
Add support for upsample_linear1d op

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -4923,6 +4923,12 @@ class PyTorchOpConverter:
             result = tvm.relay.op.add(result, block)
 
         return result
+    
+    def upsample_linear1d(self, inputs, input_types):
+        data = inputs[0]
+        out_size = inputs[1]
+
+        return _op.image.resize1d(data, out_size)
 
 
     # Operator mappings
@@ -5235,6 +5241,7 @@ class PyTorchOpConverter:
             "aten::resolve_neg": self.resolve_neg,
             "aten::unflatten": self.unflatten,
             "aten::block_diag":self.block_diag,
+            "aten::upsample_linear1d":self.upsample_linear1d,
         }
 
     def update_convert_map(self, custom_map):


### PR DESCRIPTION
### Summary 

SAM model faced `NotImplementedError: The following operators are not implemented: ['aten::upsample_linear1d']` due to this [operation](https://github.com/huggingface/transformers/blob/5d7739f15a6e50de416977fe2cc9cb516d67edda/src/transformers/models/sam/modeling_sam.py#L765C27-L765C41). This PR adds support for it 