### PR TITLE
Remove deprecated numpy dtypes from TVM framework frontend

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -475,10 +475,10 @@ class PyTorchOpConverter:
         stride = inputs[4]
 
         target_begin, is_begin_const = try_infer_value(
-            inputs[2], lambda ret: ret.astype(np.int).item(0)
+            inputs[2], lambda ret: ret.astype(int).item(0)
         )
         target_end, is_end_const = try_infer_value(
-            inputs[3], lambda ret: ret.astype(np.int).item(0)
+            inputs[3], lambda ret: ret.astype(int).item(0)
         )
 
         # A fast path when slicing is nop.
@@ -3161,7 +3161,7 @@ class PyTorchOpConverter:
             for i in [0, 1]:
                 size, _ = try_infer_value(
                     inputs[1][i],
-                    lambda ret: ret.astype(np.int),
+                    lambda ret: ret.astype(int),
                     lambda: _op.expand_dims(inputs[1][i], axis=0),
                 )
                 out_size.append(size)
@@ -5640,7 +5640,7 @@ def _convert_tvm_to_np_dtype(dtype):
     elif dtype == "uint8":
         np_type = np.uint8
     elif dtype == "bool":
-        np_type = np.bool
+        np_type = bool
     else:
         raise NotImplementedError("input_type {} is not handled yet".format(dtype))
     return np_type


### PR DESCRIPTION
### Summary 

This PR fixes https://github.com/tenstorrent/tt-forge-fe/issues/2226 by Removing deprecated numpy data types from TVM framework frontend. Root cause of the regressions is explained [here](https://github.com/tenstorrent/tt-forge-fe/pull/2256#issue-3136457294).

**Note:** No occurrences of the deprecated NumPy dtypes listed below were found in the [suggested scope](https://github.com/tenstorrent/tt-forge-fe/pull/2256/files#r2140567514), specifically under `third_party/tvm/python/tvm/relay/frontend`

```
np.float 
np.complex 
np.object 
np.str 
np.long 
np.unicode 
```

