### PR TITLE
[wheel] rename project to avoid conflicts

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -258,7 +258,7 @@ extras_require = {
 }
 
 setup(
-    name="tvm",
+    name="tt_tvm",
     version=__version__,
     description="TVM: An End to End Tensor IR/DSL Stack for Deep Learning Systems",
     long_description=long_description_contents(),


### PR DESCRIPTION
Rename project to `tt_tvm` to discern from official `tvm` in `pypi` index.