### PR TITLE
Handle tensor type bfloat16 case

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -5883,6 +5883,9 @@ def _get_constant(node):
             if len(tensor.shape) == 0:  # tensor(0.1)
                 # TODO(t-vi): When is this needed?
                 return tensor.item()
+            # Convert bfloat16 to float32 before numpy conversion since numpy doesn't support bfloat16
+            if hasattr(tensor, 'dtype') and str(tensor.dtype) == 'torch.bfloat16':
+                tensor = tensor.float()
             return _wrap_const(tensor.numpy())
         elif ty in ["DeviceObjType", "StringType"]:
             return node.s(attr_name)


### PR DESCRIPTION
## Summary
This solution is a P0 patch for the upcoming release! The follow-up issue will make a cleaner patch.

## Details
In sum, some constants aren't converted to the `flot32` data format before numpy conversion (`_wrap_const(tensor.numpy())`). We should look into more details why this path isn't covered with the existing logic for bfloat16 support. 

Performance CI ref:
- https://github.com/tenstorrent/tt-forge-fe/actions/runs/16376065137

_Bonus points: Potentially, we could explore DLPack between TVM/Torch for more seamless support._ 