### PR TITLE
[TVM][Relay][ONNX] Add explicit axis parameter to indices normalization in ONNX Gather op

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2762,7 +2762,7 @@ def normalize_gather_indices(data, indices, axis):
     """Make sure gather indices aren't negative"""
     ind_dtype = infer_type(indices).checked_type.dtype
     # Normalize the indices to a positive range
-    s = _op.take(_op.shape_of(data, dtype=ind_dtype), _op.const(axis, dtype="int64"))
+    s = _op.take(_op.shape_of(data, dtype=ind_dtype), _op.const(axis, dtype="int64"), axis=axis)
     cond = fold_constant(indices < _op.const(0, ind_dtype))
     if isinstance(cond, _expr.Constant):
         val = cond.data.numpy()


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-forge-fe/issues/2791

### Problem description

- The ssdlite320_mobilenet_v3_large ONNX model Hangs due to TypeError error in **RemoveRedundantTake**:

 ```
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

- The error originates from this [index operation](https://github.com/pytorch/vision/blob/9eb57cd5c96be7fe31923eb65399c3819d064587/torchvision/models/detection/ssd.py#L442).

### Root cause 

- Index operation is converted to gather operation during ONNX conversion.
- In the ONNX → TVM Relay conversion, the [normalize_gather_indices()](https://github.com/tenstorrent/tt-tvm/blob/71bf95ed687d649f3cd99a191d9ad9d2f51a7610/python/tvm/relay/frontend/onnx.py#L2761C5-L2761C29) function creates an internal take operation to extract dimension sizes for negative index handling.
- This take operation was created without an explicit axis parameter, which caused:
  - axis to default to None
  - A TypeError in RemoveRedundantTake when attempting to convert None to int

### What's changed 

- Added an explicit axis parameter to the take operation in normalize_gather_indices() to prevent the TypeError in RemoveRedundantTake.

### Logs

Before fix 

- [aug8_ssd_mobilenet_bf.log](https://github.com/user-attachments/files/21717355/aug8_ssd_mobilenet_af_1.log) (Hang)
- [aug8_ssd_mobilenet_bf1.log](https://github.com/user-attachments/files/21717356/aug8_ssd_mobilenet_af.log) (After keyboard interrupt)
- [aug11_block_sanity_bf.log](https://github.com/user-attachments/files/21717382/aug11_zz_bs_bf.log)
- [aug11_op_sanity_bf.log](https://github.com/user-attachments/files/21717385/aug11_zz_os_bf.log)

After Fix 

- [aug11_ssd_mobilenet_af.log](https://github.com/user-attachments/files/21717383/aug11_zz_model_af.log)
- [aug11_block_sanity_af.log](https://github.com/user-attachments/files/21717381/aug11_zz_bs_af.log)
- [aug11_op_sanity_af.log](https://github.com/user-attachments/files/21717384/aug11_zz_os_af.log)









