### PR TITLE
[TVM][Relay][ONNX] Fix axis parameter in indices normalization in ONNX Gather op

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2762,7 +2762,7 @@ def normalize_gather_indices(data, indices, axis):
     """Make sure gather indices aren't negative"""
     ind_dtype = infer_type(indices).checked_type.dtype
     # Normalize the indices to a positive range
-    s = _op.take(_op.shape_of(data, dtype=ind_dtype), _op.const(axis, dtype="int64"), axis=axis)
+    s = _op.take(_op.shape_of(data, dtype=ind_dtype), _op.const(axis, dtype="int64"), axis=0)
     cond = fold_constant(indices < _op.const(0, ind_dtype))
     if isinstance(cond, _expr.Constant):
         val = cond.data.numpy()


### PR DESCRIPTION
### Ticket 

- https://github.com/tenstorrent/tt-forge-fe/issues/2867

### Problem description

- BART ONNX model compilation fails with tensor shape mismatch error:

```
E       TVMError: The source maps are not populated for this module. Please use `tvm.relay.transform.AnnotateSpans` to attach source maps for error reporting.
E       Error: The Relay type checker is unable to show the following types match:
E         Tensor[(1024, 3072), float32]
E         Tensor[(1024, 1024), float32]
E       In particular:
E         dimension 1 conflicts: 3072 does not match 1024.
```

### Root cause 

- The issue stems from [incorrect axis parameter usage](https://github.com/tenstorrent/tt-tvm/blob/7da59f88dfaf1be1de68e5f3da71db68548338d3/python/tvm/relay/frontend/onnx.py#L2765C87-L2765C96) in the [normalize_gather_indices()](https://github.com/tenstorrent/tt-tvm/blob/71bf95ed687d649f3cd99a191d9ad9d2f51a7610/python/tvm/relay/frontend/onnx.py#L2761C5-L2761C29)  function when handling negative indices in ONNX Gather operations.
- The error originates from this [gather operation](https://github.com/huggingface/transformers/blob/51f94ea06d19a6308c61bbb4dc97c40aabd12bad/src/transformers/models/bart/modeling_bart.py#L1879C117-L1881C10) in the BART model ([:, -1, :] - selecting last element along axis 1)
- This [PR](https://github.com/tenstorrent/tt-tvm/pull/101) added axis parameter in [internal take operation](https://github.com/tenstorrent/tt-tvm/blob/7da59f88dfaf1be1de68e5f3da71db68548338d3/python/tvm/relay/frontend/onnx.py#L2765) in normalize_gather_indices() to fix [issue #2791](https://github.com/tenstorrent/tt-forge-fe/issues/2791)
- [_op.shape_of(data, dtype=ind_dtype)](https://github.com/tenstorrent/tt-tvm/blob/7da59f88dfaf1be1de68e5f3da71db68548338d3/python/tvm/relay/frontend/onnx.py#L2765C18-L2765C53) is always returns a 1-D tensor containing dimension sizes: [dim0_size, dim1_size, ...]
- As indexing is happening on axis 1 in model, passing axis=axis [here](https://github.com/tenstorrent/tt-tvm/blob/7da59f88dfaf1be1de68e5f3da71db68548338d3/python/tvm/relay/frontend/onnx.py#L2765C87-L2765C96) tries to index into axis=1 of this 1-D shape tensor (which doesn’t exist) → causing downstream shape mismatches in [GEMM](https://onnx.ai/onnx/operators/onnx__Gemm.html).
- The [previous fix](https://github.com/tenstorrent/tt-tvm/pull/101) worked for ssdlite320 mobilenetv3 ONNX only because indexing happened along axis=0, so axis=axis was equivalent to axis=0.


### What's changed

- Fixed the axis parameter in normalize_gather_indices() to prevent downstream shape propagation errors.
```
Before: _op.take(shape_tensor, axis, axis=axis)  - tries to access non-existent axis
After: _op.take(shape_tensor, axis, axis=0) - correctly indexes into 1D shape tensor
```

### Logs

Before fix 

- [aug21_sanity_bf.log](https://github.com/user-attachments/files/21918466/aug21_sanity_bf.log)
- [aug21_bart_onnx_bf.log](https://github.com/user-attachments/files/21918463/aug21_bart_onnx_bf.log)
- [aug26_op_sanity_bf.log](https://github.com/user-attachments/files/21989334/aug26_op_sanity_bf.log)




After fix

- [aug21_sanity_af_1.log](https://github.com/user-attachments/files/21918465/aug21_sanity_af_1.log)
- [aug21_bart_onnx_af1.log](https://github.com/user-attachments/files/21918461/aug21_bart_onnx_af1.log)
- [aug26_op_sanity_af.log](https://github.com/user-attachments/files/21989333/aug26_op_sanity_af.log)



